### PR TITLE
Change the widget url

### DIFF
--- a/core/components/piwikvisitssummary/elements/chunks/iframe.chunk.tpl
+++ b/core/components/piwikvisitssummary/elements/chunks/iframe.chunk.tpl
@@ -14,6 +14,6 @@
     }
 </style>
 <div id="widgetIframe" style="margin:-10px;height:240px;">
-<iframe width="100%" height="450" src="[[+protocol]]://[[+url]]index.php?module=Widgetize&action=iframe&language=[[++manager_language]]&columns[]=nb_visits&widget=1&moduleToWidgetize=VisitsSummary&actionToWidgetize=getEvolutionGraph&idSite=[[+siteid]]&period=day&date=[[+visitssummary.date]]&disableLink=1&widget=1&token_auth=[[+token_auth]]" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>
+<iframe width="100%" height="450" src="[[+protocol]]://[[+url]]index.php?module=Widgetize&action=iframe&language=[[++manager_language]]&containerId=VisitOverviewWithGraph&moduleToWidgetize=CoreHome&actionToWidgetize=renderWidgetContainer&idSite=[[+siteid]]&period=day&date=[[+visitssummary.date]]&disableLink=1&widget=1&token_auth=[[+token_auth]]" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>
 </div>
 [[+user:notempty=`<a class="piwik-directlink" href="[[+protocol]]://[[+url]]index.php?module=Login&amp;action=logme&amp;login=[[+user]]&amp;password=[[+password]]" target="_blank">[[%piwikvisitssummary.linktext]]</a>`]]

--- a/core/components/piwikvisitssummary/elements/chunks/iframe.chunk.tpl
+++ b/core/components/piwikvisitssummary/elements/chunks/iframe.chunk.tpl
@@ -13,7 +13,7 @@
         text-shadow: 0 1px 1px #fff;
     }
 </style>
-<div id="widgetIframe" style="margin:-10px;height:240px;">
-<iframe width="100%" height="450" src="[[+protocol]]://[[+url]]index.php?module=Widgetize&action=iframe&language=[[++manager_language]]&containerId=VisitOverviewWithGraph&moduleToWidgetize=CoreHome&actionToWidgetize=renderWidgetContainer&idSite=[[+siteid]]&period=day&date=[[+visitssummary.date]]&disableLink=1&widget=1&token_auth=[[+token_auth]]" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>
+<div id="widgetIframe" style="margin:-10px;height:260px;">
+<iframe width="100%" height="260" src="[[+protocol]]://[[+url]]index.php?module=Widgetize&action=iframe&language=[[++manager_language]]&containerId=VisitOverviewWithGraph&moduleToWidgetize=CoreHome&actionToWidgetize=renderWidgetContainer&idSite=[[+siteid]]&period=day&date=[[+visitssummary.date]]&disableLink=1&widget=1&token_auth=[[+token_auth]]" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>
 </div>
 [[+user:notempty=`<a class="piwik-directlink" href="[[+protocol]]://[[+url]]index.php?module=Login&amp;action=logme&amp;login=[[+user]]&amp;password=[[+password]]" target="_blank">[[%piwikvisitssummary.linktext]]</a>`]]


### PR DESCRIPTION
~~The default one has issues with Piwik 3.0.0 and shows a warning in the lower part of the widget.~~ 

Edit: It was a Piwik issue.

But the code could be changed as suggested to avoid scrolling in the widget.